### PR TITLE
feature tests for 7 work corrected small problems

### DIFF
--- a/app/controllers/server.rb
+++ b/app/controllers/server.rb
@@ -25,7 +25,11 @@ module RushHour
 
     get '/sources/:identifier/urls/:relativepath' do |identifier, relativepath|
       find_relative_path_payload_requests(identifier, relativepath)
-      erb :show
+      if @requests.count > 0
+        erb :show
+      else
+        erb :not_requested
+      end
     end
 
     get '/sources/:identifier/events/:eventname' do |identifier, eventname|

--- a/app/models/client_parser.rb
+++ b/app/models/client_parser.rb
@@ -1,4 +1,3 @@
-require 'URI'
 module ClientParser
 	def parse_client_and_direct_to_page
 		@client = Client.find_by(identifier: params['identifier'])
@@ -44,6 +43,7 @@ module ClientParser
 	def find_relative_path_payload_requests(identifier, relativepath)
 		@client = Client.find_by(identifier: identifier)
 		url = "http://#{identifier}.com/#{relativepath}"
+		# binding.pry
 		@requests = @client.find_payload_requests_by_relative_path(url)
 	end
 end

--- a/app/views/not_requested.erb
+++ b/app/views/not_requested.erb
@@ -1,0 +1,1 @@
+<h2>This Url has not been requested</h2>

--- a/test/features/user_can_view_specific_url_stats_test.rb
+++ b/test/features/user_can_view_specific_url_stats_test.rb
@@ -27,4 +27,15 @@ class UserCanViewStatsForRelativePath< FeatureTest
       assert page.has_content?("Three most popular user agents: [[\"Mozilla\", \"Windows\"], [\"Chrome\", \"Macintosh\"], [\"Opera\", \"Webkit\"]]")
     end
    end
+
+   def test_displays_error_page_for_bad_url_request
+     register_client
+     data_with_relative_path
+
+     path = '/sources/jumpstartlab/urls/blarg'
+     visit path
+     assert_equal path, current_path
+
+     assert page.has_content?("This Url has not been requested")
+   end
 end

--- a/test/models/client_test.rb
+++ b/test/models/client_test.rb
@@ -78,7 +78,10 @@ class ClientTest < Minitest::Test
    referrer_data
 
    client = Client.find(1)
-   assert_equal ["http://amazon.com", "http://newegg.com", "http://jumpstartlab.com"], client.list_top_three_referrers
+   top_three=client.list_top_three_referrers
+   combo1 = ["http://amazon.com", "http://jumpstartlab.com", "http://newegg.com"]
+   combo2 = ["http://amazon.com", "http://newegg.com", "http://jumpstartlab.com"]
+   assert (combo1==top_three) || (combo2==top_three)
   end
 
   def test_it_lists_top_three_u_agents


### PR DESCRIPTION
Feature test for iter7. Removed the `URI` require that was causing warnings. Checked- the `URI` calls still work. Added code to client test: we are getting a tie between two referrers and it's giving us 2 different possible combinations of valid output. Added an OR clause to the test to fit whichever one is returned. Created a `URL has not been requested` view per the spec and added an `if` to the server to direct to the 'not requested' page if a bad url is passed in.
