### PR TITLE
fixed the 403 duplicate payload test

### DIFF
--- a/app/controllers/server.rb
+++ b/app/controllers/server.rb
@@ -25,11 +25,7 @@ module RushHour
 
     get '/sources/:identifier/urls/:relativepath' do |identifier, relativepath|
       find_relative_path_payload_requests(identifier, relativepath)
-      if @requests.count > 0
-        erb :show
-      else
-        erb :not_requested
-      end
+      @requests.count > 0 ? (erb :show) : (erb :not_requested)
     end
 
     get '/sources/:identifier/events/:eventname' do |identifier, eventname|

--- a/app/models/client_parser.rb
+++ b/app/models/client_parser.rb
@@ -43,7 +43,6 @@ module ClientParser
 	def find_relative_path_payload_requests(identifier, relativepath)
 		@client = Client.find_by(identifier: identifier)
 		url = "http://#{identifier}.com/#{relativepath}"
-		# binding.pry
 		@requests = @client.find_payload_requests_by_relative_path(url)
 	end
 end

--- a/app/models/payload_parser.rb
+++ b/app/models/payload_parser.rb
@@ -18,10 +18,14 @@ module PayloadParser
 	end
 
 	def validate_request(identifier, params)
+		# binding.pry
 		params = params_parser(params, identifier)
+		# binding.pry
 		return [403, "Application Not Registered"] unless client_exists?(identifier)
 		return [400, "Payload Not Valid"] unless payload_valid?(params)
+		# binding.pry
 		return [403, "Already Received Request"] if payload_exists?(params)
+		# binding.pry
 		[200, "Payload Request Created"]
 	end
 
@@ -49,19 +53,22 @@ module PayloadParser
 	end
 
 	def payload_exists?(params)
+		# binding.pry
 		platform = UserAgent.parse(params['u_agent']).platform
 		browser = UserAgent.parse(params['u_agent']).browser
-		PayloadRequest.exists?(url: Url.find_or_create_by(address: params['url']),
-                               referrer: Referrer.find_or_create_by(address: params['referrer']),
-                               request_type: RequestType.find_or_create_by(verb: params['request_type']),
-                               event: Event.find_or_create_by(name: params['event']),
-                               u_agent: UAgent.find_or_create_by(browser: browser, platform: platform),
-                               resolution: Resolution.find_or_create_by(width: params['resolution_width'], height: params['resolution_height']),
-                               ip: Ip.find_or_create_by(address: params['ip']),
+		# binding.pry
+		PayloadRequest.exists?(url: Url.find_by(address: params['url']),
+                               referrer: Referrer.find_by(address: params['referrer']),
+                               request_type: RequestType.find_by(verb: params['request_type']),
+                               event: Event.find_by(name: params['event']),
+                               u_agent: UAgent.find_by(browser: browser, platform: platform),
+                               resolution: Resolution.find_by(width: params['resolution_width'], height: params['resolution_height']),
+                               ip: Ip.find_by(address: params['ip']),
 															 requested_at: params['requested_at'],
                                responded_in: params['responded_in'],
 															 client: Client.find_by(identifier: params['identifier'])
                           )
+													# binding.pry
 	end
 
 	def add_to_database(params, identifier)

--- a/app/models/url.rb
+++ b/app/models/url.rb
@@ -32,5 +32,6 @@ class Url < ActiveRecord::Base
 
   def list_top_three_u_agents_given_url
     u_agents.group(:browser, :platform).order(count: :desc).count.keys.take(3)
+    binding.pry
   end
 end

--- a/test/controllers/client_data_test.rb
+++ b/test/controllers/client_data_test.rb
@@ -42,7 +42,7 @@ class CreateClientDataTest < Minitest::Test
     assert_equal "Payload Not Valid", last_response.body
   end
 
-  def test_it_returns_403_for_repeat_data
+  def test_it_returns_200_for_good_data
     register_client
     setup_data
     pr = PayloadRequest.first
@@ -52,38 +52,30 @@ class CreateClientDataTest < Minitest::Test
     assert_equal "http://amazon.com", pr.referrer.address
     assert_equal 200, last_response.status
     assert_equal "good request", last_response.body
+  end
 
-    # setup_data
-    # [PayloadRequest.create(url: Url.find_or_create_by(address: "http://jumpstartlab.com"),
-    #                            referrer: Referrer.find_or_create_by(address: "http://amazon.com"),
-    #                            request_type: RequestType.find_or_create_by(verb: "GET"),
-    #                            event: Event.find_or_create_by(name: "facebook"),
-    #                            u_agent: UAgent.find_or_create_by(browser: "Mozilla", platform: "Windows"),
-    #                            resolution: Resolution.find_or_create_by(width: "2560", height: "1440"),
-    #                            ip: Ip.find_or_create_by(address: "63.29.38.211"),
-    #                            requested_at: "2013-02-16 21:40:00 -0700",
-    #                            responded_in: 20
-    #                           ),
-
-    #   params = {"payload"=>
-    # 						"{\"url\":\"http://jumpstartlab.com/\",
-    #             \"requestedAt\":\"2013-02-16 21:40:00 -0700\",
-    #             \"respondedIn\":20,
-    #             \"referredBy\":\"http://amazon.com\",
-    #             \"requestType\":\"GET\",
-    #             \"parameters\":[],
-    #             \"eventName\":\"facebook\",
-    #             \"userAgent\":\"Mozilla/5.0 (Windows; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1309.0 Safari/537.17\",
-    #             \"resolutionWidth\":\"2560\",
-    #             \"resolutionHeight\":\"1440\",
-    #             \"ip\":\"63.29.38.211\"}",
-   # 							"captures"=>["jumpstartlab"],
-   # 							"identifier"=>"jumpstartlab"}
-    #
-    # post 'sources/jumpstartlab/data', params
-
-    # assert_equal 403, last_response.status #TODO CHECK THIS.
-    # assert_equal "bad request", last_response.body
+  def test_it_returns_403_for_repeat_data
+    register_client
+    params = {"payload"=>
+  						"{\"url\":\"http://jumpstartlab.com/\",
+              \"requestedAt\":\"2013-02-16 21:40:00 -0700\",
+              \"respondedIn\":20,
+              \"referredBy\":\"http://amazon.com\",
+              \"requestType\":\"GET\",
+              \"parameters\":[],
+              \"eventName\":\"facebook\",
+              \"userAgent\":\"Mozilla/5.0 (Windows; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1309.0 Safari/537.17\",
+              \"resolutionWidth\":\"2560\",
+              \"resolutionHeight\":\"1440\",
+              \"ip\":\"63.29.38.211\"}",
+ 							"captures"=>["jumpstartlab"],
+ 							"identifier"=>"jumpstartlab"}
+    post 'sources/jumpstartlab/data', params
+    assert_equal 200, last_response.status
+    assert_equal "Payload Request Created", last_response.body
+    post 'sources/jumpstartlab/data', params
+    assert_equal 403, last_response.status #TODO CHECK THIS.
+    assert_equal "Already Received Request", last_response.body
   end
 
   def test_it_returns_400_for_untracked_urls


### PR DESCRIPTION
Fixed the test to return '403 error code' on a duplicate payload submission. Separated it from the test for a 200 'good' code.

For the 'top_three' searches the tied values are still generating test errors by coming out in seeming-random-order pairs.
