### PR TITLE
fixed top_three user agents test

### DIFF
--- a/app/models/url.rb
+++ b/app/models/url.rb
@@ -32,6 +32,5 @@ class Url < ActiveRecord::Base
 
   def list_top_three_u_agents_given_url
     u_agents.group(:browser, :platform).order(count: :desc).count.keys.take(3)
-    binding.pry
   end
 end

--- a/test/models/client_test.rb
+++ b/test/models/client_test.rb
@@ -88,7 +88,10 @@ class ClientTest < Minitest::Test
    referrer_data
 
    client = Client.find(1)
-   assert_equal [["Mozilla", "Windows"], ["Chrome", "Macintosh"], ["Opera", "Webkit"]], client.list_top_three_u_agents
+   combo1 = [["Mozilla", "Windows"], ["Chrome", "Macintosh"], ["Opera", "Webkit"]]
+   combo2 = [["Mozilla", "Windows"], ["Opera", "Webkit"], ["Chrome", "Macintosh"]]
+   result = client.list_top_three_u_agents
+   assert (combo1==result) || (combo2==result)
   end
 
   def test_it_lists_most_requested_verb


### PR DESCRIPTION
Added an OR to the top_three_user_agents test to handle either of the two possible orders of the tied values in the test data
